### PR TITLE
fix: hoist TDZ-bound disconnect-handler vars + x-api-key fallback for Anthropic SDK

### DIFF
--- a/proxy.mjs
+++ b/proxy.mjs
@@ -735,12 +735,19 @@ function sendJSON(res, status, data) {
 }
 
 function getApiKey(headers) {
+  // Try Authorization: Bearer header (OpenAI SDK style)
   const auth = headers['authorization'] || headers['Authorization'] || '';
-  if (!auth.startsWith('Bearer ')) return null;
-  // 从字符串中提取第一个 user_ 开头的 Key，自动清理空格/引号/多余路径
-  const match = auth.slice(7).match(/user_[a-zA-Z0-9_-]+/);
-  if (!match) return null;
-  return match[0];
+  if (auth.startsWith('Bearer ')) {
+    const match = auth.slice(7).match(/user_[a-zA-Z0-9_-]+/);
+    if (match) return match[0];
+  }
+  // Fall back to x-api-key header (Anthropic SDK style)
+  const xKey = headers['x-api-key'] || headers['X-Api-Key'] || '';
+  if (xKey) {
+    const match = xKey.match(/user_[a-zA-Z0-9_-]+/);
+    if (match) return match[0];
+  }
+  return null;
 }
 
 // ── 流式转发 ────────────────────────────────────────

--- a/proxy.mjs
+++ b/proxy.mjs
@@ -805,6 +805,9 @@ async function handleChatCompletions(req, res) {
   // AbortController 用于客户端断连时真正打断 CC 上游（pi-commandcode-provider 模式）
   const abortController = new AbortController();
   let aborted = false;
+  // 提前初始化，断连回调/超时 catch 安全引用（避免 TDZ ReferenceError）
+  const startTime = Date.now();
+  let bytesReceived = 0; let lastCcEvent = ''; let keepaliveCount = 0; let fullText = '';
 
   try {
     // 首次初始化（fingerprint + lifecycle）
@@ -822,7 +825,6 @@ async function handleChatCompletions(req, res) {
 
     let reader = null;
     let translator = null;
-    const startTime = Date.now(); let bytesReceived = 0; let lastCcEvent = ''; let keepaliveCount = 0;
 
     // 下游断连检测：打断 CC 上游 + 记录日志
     res.on('close', () => {
@@ -987,7 +989,6 @@ async function handleChatCompletions(req, res) {
       if (!res.writableEnded) res.end();
     } else {
       // ── 非流式响应（缓冲完整 NDJSON）──
-      let fullText = '';
       let reasoningContent = '';
       let finishReason = 'stop';
       let usage = null;
@@ -1515,9 +1516,13 @@ async function handleMessages(req, res) {
 
   const abortController = new AbortController();
   let aborted = false;
+  // 提前初始化，断连回调/超时 catch 安全引用（避免 TDZ ReferenceError）
+  const startTime = Date.now();
+  let messageId = '';
+  let reader = null;
+  let bytesReceived = 0; let lastCcEvent = ''; let fullText = '';
 
   try {
-    let reader = null;
     // 首次初始化（fingerprint + lifecycle）
     await ensureInitialized(apiKey, abortController.signal);
     const ccResponse = await forwardToCC(ccBody, apiKey, req.headers, abortController.signal);
@@ -1529,8 +1534,6 @@ async function handleMessages(req, res) {
       sendAnthropicError(res, mapped.status, mapped.body.error.type, mapped.body.error.message);
       return;
     }
-    const startTime = Date.now();
-    let messageId = '';
 
     // 下游断连检测：打断 CC 上游 + 记录日志
     res.on('close', () => {
@@ -1665,7 +1668,9 @@ async function handleMessages(req, res) {
     } else {
       // ── 非流式 Anthropic JSON ──
       const messageId = 'msg_' + randomUUID().slice(0, 12);
-      let bytesReceived = 0; let lastCcEvent = '';
+      let finishReason = 'stop';
+      let usage = null;
+      let toolCalls = null;
 
       reader = ccResponse.body.getReader();
       const decoder = new TextDecoder();


### PR DESCRIPTION
 ## 摘要

  `proxy.mjs` 的两个独立修复：

  1. **提升被断连回调/超时 catch 引用的 TDZ 变量**
     - `handleChatCompletions` 里 `startTime` / `bytesReceived` / `lastCcEvent` / `keepaliveCount` 声明在 try
  块内、`await forwardToCC()` 之后，却被紧接着注册的 `res.on('close')` 回调引用。当上游响应慢、客户端先断连时，close
  回调在声明执行前触发，访问暂时性死区 → `ReferenceError`。非流式空闲超时的 catch 分支同样有此风险。
     - 修复：把变量提升到函数作用域（try 之前）。`handleMessages` 同样处理（`startTime` / `messageId` / `reader` /
  `bytesReceived` / `lastCcEvent` / `fullText`），并补声明非流式 Anthropic 分支缺失的 `finishReason` / `usage` /
  `toolCalls`（同样是不稳定 `ReferenceError` 来源）。

  2. **为 Anthropic SDK 鉴权回退到 `x-api-key` header**
     - `getApiKey` 只读 `Authorization: Bearer`，而 Anthropic TS/JS SDK 不发送该 header——它用 `x-api-key` 鉴权，导致
  Anthropic SDK 客户端拿不到 key、鉴权失败。
     - 修复：无 Bearer 时回退读 `x-api-key`（大小写不敏感），用同样的正则提取 `user_` key。OpenAI 请求行为不变。

  ## 改动范围

  - 仅 `proxy.mjs`——两个 commit 合计 +23 / −11 行。
  - 无 docker-compose.yml、无配置、无依赖改动。

  ## 验证

  - `node --check proxy.mjs` 通过。
  - 每个 commit 仅改 proxy.mjs，两个 commit 相互独立（无重叠行）。