### PR TITLE
feat: retry upstream fetch on transient network errors

### DIFF
--- a/proxy.mjs
+++ b/proxy.mjs
@@ -825,6 +825,45 @@ function getApiKey(headers) {
   return null;
 }
 
+
+// ── fetch 网络层指数退避重试（本地增强，上游未实现）────────────────
+const RETRYABLE_NET_CODES = new Set([
+  'ECONNRESET','ECONNREFUSED','ETIMEDOUT','EPIPE','ENOTFOUND','EAI_AGAIN',
+  'UND_ERR_SOCKET','UND_ERR_CONNECT_TIMEOUT','UND_ERR_HEADERS_TIMEOUT','UND_ERR_BODY_TIMEOUT',
+]);
+function isRetryableFetchError(e, signal) {
+  if (e?.name === 'AbortError') return false;          // 客户端中止/空闲掐断 → 不重试
+  if (signal?.aborted) return false;
+  const c1 = e?.cause, c2 = c1?.cause;
+  const code = c1?.code || c2?.code || '';
+  if (code && RETRYABLE_NET_CODES.has(code)) return true;
+  // 裸 TypeError 'fetch failed'（无 cause）也按网络层处理
+  return (e instanceof TypeError) && e.message === 'fetch failed';
+}
+function sleepAbortable(ms, signal) {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) return reject(signal.reason || new DOMException('Aborted', 'AbortError'));
+    const t = setTimeout(done, ms);
+    const onAbort = () => { clearTimeout(t); signal.removeEventListener('abort', onAbort); reject(signal.reason || new DOMException('Aborted', 'AbortError')); };
+    function done() { clearTimeout(t); signal?.removeEventListener('abort', onAbort); resolve(); }
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+async function fetchWithRetry(url, options, retries = 2) {
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await fetch(url, options);
+    } catch (e) {
+      if (attempt >= retries || !isRetryableFetchError(e, options.signal)) throw e;
+      attempt++;
+      const delayMs = 300 * (2 ** (attempt - 1));      // 第1次重试等300ms, 第2次600ms
+      log('warn', 'Upstream network retry', { attempt, cause: (e?.cause?.code || e.message), retryInMs: delayMs });
+      await sleepAbortable(delayMs, options.signal);
+    }
+  }
+}
+
 // ── 流式转发 ────────────────────────────────────────
 
 async function forwardToCC(body, apiKey, incomingHeaders = {}, signal, promptCacheKey) {
@@ -848,7 +887,7 @@ async function forwardToCC(body, apiKey, incomingHeaders = {}, signal, promptCac
     headers['x-cmd-zdr'] = '1';
   }
 
-  const response = await fetch(url, {
+  const response = await fetchWithRetry(url, {
     method: 'POST',
     headers,
     body: JSON.stringify(body),


### PR DESCRIPTION
背景: 实测仍有 ~2% 请求在 CC 上游瞬时网络抖动时直接 502 (fetch failed, cause=ETIMEDOUT/ECONNRESET ~500ms)。

改法: forwardToCC 的 fetch 包指数退避重试(最多3次尝试, 300ms→600ms)。只在"未收到任何响应"的网络层失败时重试; AbortError / HTTP 业务错误 / 流中途断线一律不重试, 不影响现有错误透传。

验证: 单测全绿 + 活体负载下无用户可见网络 502。