### PR TITLE
perf: release the original request tree after buildCcRequest (issue #20)

### DIFF
--- a/proxy.mjs
+++ b/proxy.mjs
@@ -1018,6 +1018,10 @@ async function handleChatCompletions(req, res) {
 
   // 构建 CC 请求体
   const ccBody = buildCcRequest(openaiReq);
+  // 断开原始请求树：ccBody 建好后，整棵树只剩 prompt_cache_key 还被用到。
+  // 先取出该值再释放引用，让这份副本能被更早回收 —— 原先它与 ccBody 一起活到请求结束。
+  const promptCacheKey = openaiReq.prompt_cache_key;
+  openaiReq = null;
 
   // AbortController 用于客户端断连时真正打断 CC 上游（pi-commandcode-provider 模式）
   const abortController = new AbortController();
@@ -1032,7 +1036,7 @@ async function handleChatCompletions(req, res) {
     // 首次初始化（fingerprint + lifecycle）
     await ensureInitialized(apiKey, abortController.signal);
     // 转发到 CC API（传入客户端 headers，用于提取 session ID）
-    const ccResponse = await forwardToCC(ccBody, apiKey, req.headers, abortController.signal, openaiReq.prompt_cache_key);
+    const ccResponse = await forwardToCC(ccBody, apiKey, req.headers, abortController.signal, promptCacheKey);
 
     if (!ccResponse.ok) {
       const errorText = await ccResponse.text().catch(() => '');
@@ -1824,8 +1828,12 @@ async function handleMessages(req, res) {
   const model = anthropicReq.model || 'claude-sonnet-4-6';
 
   // Convert Anthropic → OpenAI → CC
-  const openaiReq = convertAnthropicToOpenAI(anthropicReq);
+  let openaiReq = convertAnthropicToOpenAI(anthropicReq);
   const ccBody = buildCcRequest(openaiReq);
+  // 断开两棵中间树：ccBody 建好后 anthropicReq / openaiReq 都不再被引用。
+  // messages 路径此前同时持有两棵树，与 ccBody 一起活到请求结束。
+  openaiReq = null;
+  anthropicReq = null;
 
   const abortController = new AbortController();
   let aborted = false;
@@ -2604,7 +2612,11 @@ async function handleResponses(req, res) {
   };
   const ccBody = buildCcRequest(chatReq);
   const promptCacheKey = chatReq.prompt_cache_key;
+  // 断开两棵请求树：ccBody 建好后，转换后的 chatReq 与原始 respReq 都不再被引用。
+  // respReq 是 Codex 送来的完整会话（input items 原始形态），比 chatReq 还大一份 ——
+  // 原先它与 ccBody 一起活到请求结束。
   chatReq = null;
+  respReq = null;
 
   const abortController = new AbortController();
   let aborted = false;


### PR DESCRIPTION
## 这条 PR 是什么

`buildCcRequest` 建好 `ccBody` 之后，原始请求树就不再被引用了，但此前它与 `ccBody` 一起活到请求结束。三条路径各自断开引用：

| 路径 | 断开的树 |
|---|---|
| `/v1/chat/completions` | `openaiReq`（先取出 `prompt_cache_key`） |
| `/v1/messages` | `anthropicReq` + `openaiReq` |
| `/v1/responses` | `respReq` + `chatReq` |

`/v1/responses` 是 `7488662` 新增的端点。它已经释放了转换后的 `chatReq`，但**没有释放原始 `respReq`** —— 而 `respReq` 是 Codex 送来的完整会话（input items 原始形态），比 `chatReq` 还大一份。

---

## ⚠️ 请按「清理」而不是「内存优化」评估

#20 里说这是 "4 lines with a clear win"。**内存收益我量不出来，这个判断我收回。**

8MB body × 8 并发，慢上游把生命周期拉长到数秒，60ms 采样 RSS，3 轮交错：

| | run1 | run2 | run3 |
|---|---|---|---|
| upstream `a941812` | +265 MB | +274 MB | +314 MB |
| 本 PR | +281 MB | +273 MB | +282 MB |

**完全重叠。** 不是噪声淹没小收益，原因是结构性的：

1. **chat 路径载荷是共享的** —— `buildCcRequest` 写的是 `{ type: 'text', text: msg.content }`，字符串是**引用不是拷贝**。释放 `openaiReq` 回收的只是外层对象图。
2. **messages 路径那份"副本"也没释放掉** —— `textContent += block.text` 在 V8 里产生 **ConsString**，仍引用原始分片。
3. **峰值 ≠ 驻留** —— 5.5× 放大发生在 parse + 重建 + `JSON.stringify` 期间，那一刻所有副本按定义都活着；释放发生在这之后。OOM 看的是峰值。

所以：可以当清理合掉，也可以关掉，但**不要写进 README 的内存与部署数字里**。

---

## 正确性：A/B 逐字节一致

同一 mock 上游、同一 cwd，仅屏蔽 `traceparent` / `content-length` / `config.workingDir|date|structure`，比较两边抓到的 `/alpha/generate`：

6 个用例 —— chat 流式含 `prompt_cache_key`、同 key 第二次、chat 非流式、`/v1/messages`、`/v1/responses` 流式、`/v1/responses` 非流式 —— **diff 为空，全部 200**。

释放请求树的整个主张就是零行为变化，这条能被逐字节证明。
