### PR TITLE
feat: 支持为上游请求配置 HTTP(S) 代理（issue #18，零依赖 CONNECT 隧道）

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ commandcode/
 | `CC_NONSTREAM_IDLE_MS` | Non-streaming upstream read idle timeout (default `90000`) |
 | `CC_MAX_INFLIGHT` | In-process concurrent request cap (default `0` = unlimited) |
 | `CMD_ZDR` | `zdr` (`1` to enable) |
+| `CC_UPSTREAM_PROXY` | `upstreamProxy` |
 
 When enabled, the proxy sends `x-cmd-zdr: 1` on Command Code generation requests
 and the fingerprint/lifecycle initialization requests. It does not add the header
@@ -85,7 +86,27 @@ authority for actual retention and provider availability.
 
 **Request body limit**: independent of `config.json` — requests larger than **100 MB** are rejected with `HTTP 413` (the connection is kept alive and drained, not reset). Override with `CC_MAX_BODY_MB` (positive integer, unit: MB).
 
-> ⚠️ **Memory amplification**: a request body exists in several copies before it reaches upstream; measured peak ≈ body size × **5.1–7.4** (7 MB → +52 MB, 20 MB → +116 MB, while a request rejected with `413` costs only ×1.05). The default `CC_MAX_BODY_MB=100` therefore implies up to ~550 MB for a **single** request, and that limit is per-request, not global. See [Memory & Deployment](#memory--deployment).
+> ⚠️ **Memory amplification**: a request body exists in several copies before it reaches upstream; measured peak ≈ body size × **5.1–7.4** (7 MB → +52 MB, 20 MB → +116 MB, while a request rejected with `413` costs only ×1.05). The default `CC_MAX_BODY_MB=100` therefore implies up to ~550 MB for a **single** request, and the limit is per-request, not global. See [Memory & Deployment](#memory--deployment).
+
+### Upstream proxy (`upstreamProxy` / `CC_UPSTREAM_PROXY`)
+
+Route the requests the proxy makes **to Command Code** through a local HTTP proxy — for egress-region switching, or for comparing IPs when debugging risk-control `403`s.
+
+```json
+{ "upstreamProxy": "http://127.0.0.1:7890" }
+```
+
+```bash
+CC_UPSTREAM_PROXY=http://127.0.0.1:7890 npm start
+```
+
+- Applies to `/alpha/generate`, `/alpha/fingerprint/record`, `/alpha/lifecycle-events` and `/provider/v1/models`.
+- **Does not** touch the local listener, `/health`, or the npm version check.
+- Only `http://` (CONNECT) proxies are supported. Implemented with a plain CONNECT tunnel plus `node:https`, so there is **no new dependency** and it works on Node 18+.
+- Each upstream request opens its own tunnel connection. TLS is end-to-end: the certificate is validated against `api.commandcode.ai`, never against the proxy.
+- Routing the fingerprint/lifecycle pre-requests through the same proxy matters: if they went out direct while generation went through the proxy, one account would register from two different IPs — exactly the inconsistency you are trying to avoid.
+
+> Node's built-in `fetch` does **not** read `HTTPS_PROXY`/`HTTP_PROXY`. The official env-var route requires Node ≥ 22.21 / 24.5 plus `NODE_USE_ENV_PROXY=1`; this option works without either.
 
 ## API Endpoints
 
@@ -469,6 +490,7 @@ npm run docker:build:multi
 | `PORT` | `3050` | Container listen port |
 | `PROXY_PORT` | `3050` | Host port (compose only) |
 | `CC_MAX_BODY_MB` | `100` | Max request body size in MB; oversized requests are rejected with `HTTP 413` |
+| `CC_UPSTREAM_PROXY` | *(unset)* | `http://host:port` CONNECT proxy for upstream Command Code requests only |
 | `CC_CLIENT_DRAIN_TIMEOUT_MS` | *(unset = disabled)* | Drop the client and abort upstream when downstream backpressure blocks longer than this; see [Stalled clients](#stalled-clients-neither-reading-nor-disconnecting) |
 | `CC_STREAM_IDLE_MS` | `30000` | Streaming upstream read idle timeout in ms; see [Upstream idle timeouts](#upstream-idle-timeouts) |
 | `CC_NONSTREAM_IDLE_MS` | `90000` | Non-streaming upstream read idle timeout in ms |
@@ -542,7 +564,7 @@ The body exists in several copies before being forwarded: `chunks[]` / `Buffer.c
 | 20 MB | 100 MB | +116 MB (5.8×) | 200 |
 | 20 MB | 8 MB | +21 MB (1.05×) | **413** |
 
-At startup a `warn` is logged when the implied worst case is ≥ 500 MB. The limit is **per request** and the proxy does no in-flight limiting of its own — a public deployment must add both at the reverse proxy.
+At startup a `warn` is logged when the implied worst case is ≥ 500 MB. The body limit is **per request** — cap the multiplier with `CC_MAX_INFLIGHT` (in-process, global only), and add per-IP / per-key limits in the reverse proxy. A public deployment should do both.
 
 ### Suggested nginx front
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -76,6 +76,7 @@ commandcode/
 | `CC_NONSTREAM_IDLE_MS` | 非流式上游读空闲超时（默认 `90000`）|
 | `CC_MAX_INFLIGHT` | 进程内在途请求上限（默认 `0` = 不限）|
 | `CMD_ZDR` | `zdr`（`1` 开启） |
+| `CC_UPSTREAM_PROXY` | `upstreamProxy` |
 
 开启后，代理会在 Command Code 生成请求以及 fingerprint/lifecycle 初始化请求中附加
 `x-cmd-zdr: 1`。npm 版本检查和代理自己的 `/provider/v1/models` 模型目录请求不会附加该
@@ -84,6 +85,26 @@ header。该开关只是请求 Command Code 使用 ZDR-only 路由，实际数�
 **请求体上限**：独立于 `config.json` —— 超过 **100MB** 的请求会被拒绝并返回 `HTTP 413`（连接保持可排空，不会直接 reset）。可用 `CC_MAX_BODY_MB`（正整数，单位 MB）覆盖。
 
 > ⚠️ **内存放大**：请求体在转发到上游前会存在多份副本，实测峰值 ≈ body 大小 × **5.1~7.4**（7MB→+52MB、20MB→+116MB；被 `413` 拒绝的请求只要 ×1.05）。因此默认 `CC_MAX_BODY_MB=100` 意味着**单个请求**最坏可吃 ~550MB，且该上限是每请求的、不是全局的。详见[内存与部署](#内存与部署)。
+
+### 上游代理（`upstreamProxy` / `CC_UPSTREAM_PROXY`）
+
+让代理**发往 Command Code 的请求**走本地 HTTP 代理 —— 用于出口地区调整，或排查风控 `403` 时做 IP 维度对照。
+
+```json
+{ "upstreamProxy": "http://127.0.0.1:7890" }
+```
+
+```bash
+CC_UPSTREAM_PROXY=http://127.0.0.1:7890 npm start
+```
+
+- 作用于 `/alpha/generate`、`/alpha/fingerprint/record`、`/alpha/lifecycle-events` 与 `/provider/v1/models`。
+- **不影响**本地监听、`/health` 与 npm 版本检查。
+- 仅支持 `http://`（CONNECT）代理。实现方式是自建 CONNECT 隧道 + `node:https` 复用同一 socket，**不新增任何依赖**，Node 18+ 即可用。
+- 每个上游请求各自建立一条隧道连接。TLS 为端到端：证书按 `api.commandcode.ai` 校验，绝不针对代理降级。
+- **指纹/lifecycle 预请求也走代理**是刻意的：若它们直连而上游生成走代理，同一账号会从两个不同 IP 注册 —— 正是你想避免的那种矛盾。
+
+> Node 原生 `fetch` **不读** `HTTPS_PROXY`/`HTTP_PROXY`。官方环境变量路线需要 Node ≥ 22.21 / 24.5 且设 `NODE_USE_ENV_PROXY=1`；本选项两者都不需要。
 
 ## API 接口
 
@@ -467,6 +488,7 @@ npm run docker:build:multi
 | `PORT` | `3050` | 容器内监听端口 |
 | `PROXY_PORT` | `3050` | 主机映射端口（仅 compose） |
 | `CC_MAX_BODY_MB` | `100` | 请求体大小上限（MB），超限请求返回 `HTTP 413` |
+| `CC_UPSTREAM_PROXY` | 空 | 仅作用于 CC 上游请求的 `http://host:port` CONNECT 代理 |
 | `CC_CLIENT_DRAIN_TIMEOUT_MS` | 空（禁用）| 下游背压阻塞超过该毫秒数则断开该客户端并中止上游请求，见[僵死连接](#僵死连接既不读也不断开) |
 | `CC_STREAM_IDLE_MS` | `30000` | 流式上游读空闲超时（毫秒），见[上游空闲超时](#上游空闲超时) |
 | `CC_NONSTREAM_IDLE_MS` | `90000` | 非流式上游读空闲超时（毫秒）|
@@ -546,7 +568,7 @@ body 在转发到上游前同时存在多份副本：`chunks[]` / `Buffer.concat
 | 20 MB | 100 MB | +116 MB（5.8×）| 200 |
 | 20 MB | 8 MB | +21 MB（1.05×）| **413** |
 
-启动时若隐含最坏峰值 ≥ 500MB，日志会输出 `warn` 提示。上限是**按请求**的，proxy 自身没有在途限流 —— 公网部署必须在反向代理层补上。
+启动时若隐含最坏峰值 ≥ 500MB，日志会输出 `warn` 提示。body 上限是**按请求**的 —— 乘数用 `CC_MAX_INFLIGHT`（进程内、仅全局）封顶，按 IP / 按 key 的限流在反向代理层补上。公网部署建议两者都做。
 
 ### nginx 反代建议
 

--- a/config.json
+++ b/config.json
@@ -6,5 +6,6 @@
   "projectSlug": "cc-proxy",
   "logFile": "",
   "logLevel": "info",
-  "zdr": false
+  "zdr": false,
+  "upstreamProxy": ""
 }

--- a/proxy.mjs
+++ b/proxy.mjs
@@ -3,6 +3,9 @@
  * 基于真实 CLI 流量抓包数据构建
  */
 import http from 'http';
+import https from 'https';
+import tls from 'tls';
+import { Readable } from 'stream';
 import crypto from 'crypto';
 import { randomUUID } from 'crypto';
 import { readFileSync, existsSync, appendFileSync } from 'fs';
@@ -24,6 +27,7 @@ function loadConfig() {
     modelRefreshIntervalMs: 5 * 60 * 1000,  // 5 minutes
     zdr: false,
     emptySystemPlaceholder: true, // 无 system prompt 时发空格占位，阻止 CC 上游注入 ~7.5K token 默认提示词（issue #17）
+    upstreamProxy: '',            // 上游 HTTP 代理，如 http://127.0.0.1:7890（issue #18）
   };
 
   const configPath = resolve(__dirname, 'config.json');
@@ -45,6 +49,7 @@ function loadConfig() {
   if (process.env.CC_USE_PROVIDER_MODELS) defaults.useProviderModels = process.env.CC_USE_PROVIDER_MODELS !== 'false';
   if (process.env.CMD_ZDR !== undefined) defaults.zdr = process.env.CMD_ZDR === '1';
   if (process.env.CC_EMPTY_SYSTEM_PLACEHOLDER) defaults.emptySystemPlaceholder = process.env.CC_EMPTY_SYSTEM_PLACEHOLDER !== 'false';
+  if (process.env.CC_UPSTREAM_PROXY) defaults.upstreamProxy = process.env.CC_UPSTREAM_PROXY;
 
   return defaults;
 }
@@ -309,7 +314,7 @@ async function ensureInitialized(apiKey, signal) {
     const fingerprint = state.fingerprint || {};
 
     await Promise.all([
-      fetch(`${CFG.apiBase}/alpha/fingerprint/record`, {
+      upstreamFetch(`${CFG.apiBase}/alpha/fingerprint/record`, {
         method: 'POST', headers, signal,
         body: JSON.stringify(fingerprint),
       }).then(r => {
@@ -319,7 +324,7 @@ async function ensureInitialized(apiKey, signal) {
         if (e.name !== 'AbortError') log('warn', 'Fingerprint record error', { error: e.message });
       }),
 
-      fetch(`${CFG.apiBase}/alpha/lifecycle-events`, {
+      upstreamFetch(`${CFG.apiBase}/alpha/lifecycle-events`, {
         method: 'POST', headers, signal,
         body: JSON.stringify({
           eventType: 'cli_session_exists',
@@ -957,6 +962,117 @@ function getApiKey(headers) {
   return null;
 }
 
+// ── 上游 HTTP(S) 代理（issue #18）────────────────────
+// 仅作用于发往 CC 上游的请求（/alpha/generate、/provider/v1/models）。
+// 本地监听、/health 与 npm registry 版本检查都不经过代理。
+//
+// 零依赖实现：自己建立 CONNECT 隧道，再用 node:https 复用同一个 socket，
+// 因此不需要 undici / https-proxy-agent，engines >=18 也能用。
+// 注意 Node 原生 fetch 不读 HTTPS_PROXY/HTTP_PROXY；官方的环境变量方案需要
+// Node >= 22.21 / 24.5 并设 NODE_USE_ENV_PROXY=1（README 有说明）。
+const UPSTREAM_PROXY = CFG.upstreamProxy || '';
+const PROXY_CONNECT_TIMEOUT_MS = 15000;
+
+function parseProxyUrl(raw) {
+  let u;
+  try {
+    u = new URL(raw);
+  } catch {
+    throw new Error(`upstreamProxy is not a valid URL: ${raw}`);
+  }
+  if (u.protocol !== 'http:') {
+    throw new Error(`upstreamProxy only supports http:// (CONNECT) proxies, got ${u.protocol}//`);
+  }
+  const auth = u.username
+    ? 'Basic ' + Buffer.from(`${decodeURIComponent(u.username)}:${decodeURIComponent(u.password)}`).toString('base64')
+    : null;
+  return { host: u.hostname, port: Number.parseInt(u.port || '80', 10), auth };
+}
+
+/** Response 的 headers 需要字符串值；node 的 set-cookie 是数组，展开为多行。 */
+function headersToInit(raw) {
+  const out = [];
+  for (const [k, v] of Object.entries(raw)) {
+    if (Array.isArray(v)) { for (const item of v) out.push([k, String(item)]); }
+    else if (v !== undefined) out.push([k, String(v)]);
+  }
+  return out;
+}
+
+/** 经 HTTP 代理发上游请求，返回与 fetch 兼容的 Response（.ok/.status/.text()/.body）。 */
+async function proxyFetch(urlStr, options = {}) {
+  const proxy = parseProxyUrl(UPSTREAM_PROXY);
+  const u = new URL(urlStr);
+  const isTls = u.protocol === 'https:';
+  const port = Number.parseInt(u.port || (isTls ? '443' : '80'), 10);
+  const target = `${u.hostname}:${port}`;
+  const { signal, body } = options;
+  const onAbort = (fn) => { if (signal) signal.addEventListener('abort', fn, { once: true }); };
+
+  // 1. CONNECT 隧道 —— 代理只做裸字节转发，TLS 由本端端到端完成
+  const rawSocket = await new Promise((resolve, reject) => {
+    const connectReq = http.request({
+      host: proxy.host,
+      port: proxy.port,
+      method: 'CONNECT',
+      path: target,
+      headers: { Host: target, ...(proxy.auth ? { 'Proxy-Authorization': proxy.auth } : {}) },
+      timeout: PROXY_CONNECT_TIMEOUT_MS,
+    });
+    connectReq.on('connect', (res, socket) => {
+      if (res.statusCode !== 200) {
+        socket.destroy();
+        reject(new Error(`upstream proxy CONNECT ${target} failed: HTTP ${res.statusCode}`));
+        return;
+      }
+      resolve(socket);
+    });
+    connectReq.on('timeout', () => connectReq.destroy(new Error('upstream proxy CONNECT timeout')));
+    connectReq.on('error', reject);
+    onAbort(() => { try { connectReq.destroy(); } catch {} });
+    connectReq.end();
+  });
+
+  // 2. 隧道上做 TLS（证书按目标主机名校验，不做任何降级）
+  let socket = rawSocket;
+  if (isTls) {
+    socket = tls.connect({ socket: rawSocket, servername: u.hostname });
+    await new Promise((resolve, reject) => {
+      socket.once('secureConnect', resolve);
+      socket.once('error', reject);
+      onAbort(() => { try { socket.destroy(); } catch {} });
+    });
+  }
+
+  // 3. 复用隧道 socket 发请求
+  return await new Promise((resolve, reject) => {
+    const mod = isTls ? https : http;
+    const req = mod.request({
+      host: u.hostname,
+      port,
+      path: u.pathname + u.search,
+      method: options.method || 'GET',
+      headers: options.headers || {},
+      createConnection: () => socket,
+    }, (res) => {
+      resolve(new Response(Readable.toWeb(res), {
+        status: res.statusCode,
+        statusText: res.statusMessage,
+        headers: headersToInit(res.headers),
+      }));
+    });
+    req.on('error', reject);
+    onAbort(() => { try { req.destroy(); } catch {} });
+    if (body !== undefined && body !== null) req.write(body);
+    req.end();
+  });
+}
+
+/** 上游请求入口：配了代理走隧道，否则用原生 fetch（默认路径行为完全不变）。 */
+function upstreamFetch(urlStr, options) {
+  return UPSTREAM_PROXY ? proxyFetch(urlStr, options) : fetch(urlStr, options);
+}
+
 // ── 流式转发 ────────────────────────────────────────
 
 async function forwardToCC(body, apiKey, incomingHeaders = {}, signal, promptCacheKey) {
@@ -980,7 +1096,7 @@ async function forwardToCC(body, apiKey, incomingHeaders = {}, signal, promptCac
     headers['x-cmd-zdr'] = '1';
   }
 
-  const response = await fetch(url, {
+  const response = await upstreamFetch(url, {
     method: 'POST',
     headers,
     body: JSON.stringify(body),
@@ -2138,7 +2254,7 @@ async function fetchModels(apiKey) {
   try {
     if (!apiKey || !CFG.useProviderModels) throw new Error('Provider models disabled');
 
-    const response = await fetch(`${CFG.apiBase}/provider/v1/models`, {
+    const response = await upstreamFetch(`${CFG.apiBase}/provider/v1/models`, {
       headers: {
         'Authorization': `Bearer ${apiKey}`,
         'x-cli-environment': 'production',
@@ -2936,6 +3052,7 @@ server.listen(CFG.port, CFG.host, () => {
     clientDrainTimeout: CLIENT_DRAIN_TIMEOUT_MS > 0 ? `${CLIENT_DRAIN_TIMEOUT_MS}ms` : 'disabled',
     idleTimeouts: `stream ${STREAM_IDLE_TIMEOUT_MS}ms / nonstream ${NONSTREAM_IDLE_TIMEOUT_MS}ms`,
     maxInflight: MAX_INFLIGHT > 0 ? `${MAX_INFLIGHT} (global, /health exempt)` : 'unlimited (CC_MAX_INFLIGHT=0)',
+    upstreamProxy: UPSTREAM_PROXY || '(direct)',
   });
   if (CLIENT_DRAIN_TIMEOUT_MS > 0) {
     log('info', 'Client drain timeout enabled', { timeoutMs: CLIENT_DRAIN_TIMEOUT_MS });
@@ -2947,7 +3064,7 @@ server.listen(CFG.port, CFG.host, () => {
     log('warn', 'Request body limit implies high per-request worst-case memory', {
       maxBodyMB: bodyCapMB,
       worstCaseRSSPerRequestMB: worstCaseMB,
-      hint: 'lower CC_MAX_BODY_MB and/or cap in-flight requests at the reverse proxy (see README)',
+      hint: 'lower CC_MAX_BODY_MB, set CC_MAX_INFLIGHT, and/or cap in-flight requests at the reverse proxy (see README)',
     });
   }
   if (!CFG.apiKey) {


### PR DESCRIPTION
Closes #18.

## 为什么用自建 CONNECT 隧道而不是依赖

Node 原生 `fetch` **不读** `HTTPS_PROXY` / `HTTP_PROXY`。官方路线是 `NODE_USE_ENV_PROXY=1`，但它需要 Node ≥ 22.21 / 24.5，而本项目的 Dockerfile 是 `node:22-alpine`、`engines` 声明 `>=18` —— 用它会顺带把最低版本要求抬上去。

另一条路是 `undici` 的 `ProxyAgent` 或 `https-proxy-agent`，但那是给一个「单文件、零外部依赖」的项目引入第一个运行时依赖。

所以这里用零依赖实现：自己发 `CONNECT`，拿到裸 socket 后交给 `node:https` 复用它。

```
net.connect(proxy) → CONNECT host:443 → 200 → tls.connect({ socket }) → https.request({ createConnection })
```

**TLS 是端到端的** —— 证书按 `api.commandcode.ai` 校验（`servername` 显式传入），代理只转发裸字节，全程不解密。`engines >=18` 不变。

## 覆盖范围

| 请求 | 是否走代理 |
|---|---|
| `/alpha/generate` | ✅ |
| `/alpha/fingerprint/record` | ✅ |
| `/alpha/lifecycle-events` | ✅ |
| `/provider/v1/models` | ✅ |
| 本地监听 / `/health` | ❌ |
| npm registry 版本检查 | ❌ |

**预请求也走代理是刻意的**：如果 fingerprint / lifecycle 直连而上游生成走代理，同一个账号会从两个不同 IP 注册 —— 那正是这个 issue 想消除的矛盾。

## 用法

```json
{ "upstreamProxy": "http://127.0.0.1:7890" }
```

```bash
CC_UPSTREAM_PROXY=http://127.0.0.1:7890 npm start
```

支持 `http://user:pass@host:port` 形式（转成 `Proxy-Authorization`）。

## 验证

mock 上游 + 录制型 CONNECT 代理（记录每条 CONNECT 的 target）：

```
[2] 上游代理 CC_UPSTREAM_PROXY（issue #18）
  PASS  经代理请求成功 status=200
  PASS  CONNECT 隧道已建立 -> ["127.0.0.1:4961","127.0.0.1:4961","127.0.0.1:4961"]
  PASS  generate 经隧道到达上游
  PASS  fingerprint + lifecycle 也走了代理
  PASS  /health 未经过代理
```

三条 CONNECT 正好对应 generate + fingerprint + lifecycle。两个端点在配代理与不配代理下均无回归。

## 说明

本 PR 只含 #18。`/v1/chat/completions` 与 `/v1/messages` 的请求树提前释放是另一件事，已单独提在 #23。
