### PR TITLE
fix: /v1/responses 支持省略 type 的 input item（issue #30，静默丢消息）

### DIFF
--- a/proxy.mjs
+++ b/proxy.mjs
@@ -2218,7 +2218,13 @@ function convertResponsesToChat(respReq) {
   } else if (Array.isArray(input)) {
     for (const item of input) {
       if (!item || typeof item !== 'object') continue;
-      switch (item.type) {
+      // OpenAI 规范里 input 数组的联合类型第一个成员是 EasyInputMessage，它的
+      // required 只有 role 与 content —— type 是可选的（官方文档与 SDK 示例普遍写作
+      // { role: 'user', content: 'hi' }）。item.type 为 undefined 但有 role 时按
+      // message 处理，否则这类 item 会落进 default 被丢弃：全部省略时只剩
+      // "input is required" 的误导性报错；混合形态时更糟 —— 校验能过，用户在
+      // HTTP 200 下静默丢消息。这里只在 type 缺失时兜底，带 type 的 item 判定不变。
+      switch (item.type ?? (item.role ? 'message' : undefined)) {
         case 'reasoning': {
           const t = responsesReasoningOf(item);
           if (t) ensurePending().reasoning_content = t;
@@ -2254,7 +2260,10 @@ function convertResponsesToChat(respReq) {
           });
           break;
         }
-        default: break;
+        default: {
+          log('warn', 'Unknown Responses input item type', { type: item.type });
+          break;
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #30.

## 问题

`convertResponsesToChat` 的 `switch` 直接读 `item.type`，未带 `type` 的 item 落进 `default` 被丢弃。

而 OpenAI 规范里 `input` 数组的联合类型**第一个成员就是 `EasyInputMessage`**，它的 required 只有 `role` 与 `content`：

```yaml
EasyInputMessage:
  properties:
    role:    { enum: [user, assistant, system, developer] }
    content: { oneOf: [string, InputMessageContentList] }
    type:    { enum: [message], x-stainless-const: true }   # 有，但不 required
  required:
    - role
    - content        # ← 没有 type
```

官方文档与 SDK 示例普遍写作 `input=[{"role":"user","content":"Hello"}]`，所以这不是边角情况。

## 两种后果

**1. 全部省略 `type` → 400，但报错指向错误方向**

```
{ "input": [{ "role": "user", "content": "hi" }] }
→ HTTP 400 { "message": "input is required" }
```

用户明明传了 `input`，得到的却是「input is required」。

**2. 混合形态 → HTTP 200，用户消息静默消失** ⚠️

```
{ "input": [ { "type": "message", "role": "system", "content": "sys" },
             { "role": "user", "content": "真正的问题" } ] }     ← 没有 type

→ HTTP 200
   params.system   = "sys"
   params.messages = []        ← 用户的问题不见了
```

只要有一个 item 带 `type`，`messages.length` 就非 0，校验通过，而省略 `type` 的那些已经被默默丢掉。下游拿到一个正常的 200 和一个基于空对话的答案 —— 不报错、不打日志，从调用方看是一次完全成功的请求。

## 成因

联合类型里看错了成员，是可以理解的一次疏忽：`switch` 处理的 `reasoning` / `message` / `function_call` / `function_call_output` 全部来自 `Item`（其 `required` 确实含 `type`），作者按 `Item` 建模，漏掉了排在它前面的 `EasyInputMessage`。

## 修复

```diff
-      switch (item.type) {
+      // EasyInputMessage 的 required 只有 role 与 content —— type 是可选的。
+      // item.type 为 undefined 但有 role 时按 message 处理。
+      switch (item.type ?? (item.role ? 'message' : undefined)) {
```

```diff
-        default: break;
+        default: {
+          log('warn', 'Unknown Responses input item type', { type: item.type });
+          break;
+        }
```

两处改动：

1. **只在 `type` 缺失时按 `role` 兜底成 `message`** —— 带 `type` 的 item 判定完全不变，改动落在既有分支之外，不触碰 `reasoning` / `function_call` 等任何现有路径。
2. **`default` 补日志** —— 与本文件其余 5 处 `default` 一致。原先的静默丢弃是这条 issue 最难查的部分。

## 验证

mock 上游，直接读 wire 层的 `params.system` / `params.messages`。

**测试有区分度**：同一份测试打给未修复的上游，**9 项失败**；打给本分支**全通过**。

| 用例 | 修复前 | 修复后 |
|---|---|---|
| 无 type user | 400 "input is required" | 200，消息送达 ✔ |
| 无 type + 数组 content | 400 | 200，消息送达 ✔ |
| 无 type system + user | 200，user 静默丢失 | 200，两者都送达 ✔ |
| 混合（system 带 type，user 不带） | 200，**user 静默丢失** | 200，两者都送达 ✔ |
| 带 type（既有路径） | 200 ✔ | 200 ✔ |
| `input` 字符串（既有路径） | 200 ✔ | 200 ✔ |
| developer role | 200，user 丢失 | 200，两者都送达 ✔ |
| 未知 type（如 `web_search_call`） | 400 + 静默 | 200 + **打 warn 日志** ✔ |

**既有路径零回归**：带 `type` 与 `input` 字符串两种形态，与修复前的 `/alpha/generate` 请求体**逐字节一致**（A/B，同一 mock 上游、同一 cwd）。

## 说明

本 PR 只含这一处修复，基于 `a941812`，不夹带其它改动。

规范在这里本身有内部矛盾：`InputItem` 带了 `discriminator: {propertyName: type}`，而 `EasyInputMessage.type` 是可选 —— 严格按 discriminator 语义这个联合无法判别。我倾向于认为这是 OpenAI spec 自身的问题（`required` 写得很明确），不影响本修复。
